### PR TITLE
[role/libre] Remove dependency on ipa-server

### DIFF
--- a/ansible/roles/libre/tasks/install/services.yml
+++ b/ansible/roles/libre/tasks/install/services.yml
@@ -10,8 +10,8 @@
     - docker
     - bind-utils
     - rng-tools
-    - ipa-server
     - bash-completion
+    #- ipa-server # TODO: Move this prerequisite to the infra/prem role
 - name: "install_services : Force upgrading pip packages manager"
   command: "pip install --upgrade pip"
 - name: "install_services : Install and force upgrade pip packages"


### PR DESCRIPTION
This package installation should only performed by the appropriate infra
role (probably infra/prem) once we figure out how to handle it.

Fixes #12 