### PR TITLE
Revert "[ansible] Use the merge strategy for overriding hashes"

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,6 +3,5 @@ inventory=inventory
 host_key_checking=false
 roles_path=roles/
 private_key_file=~/.ssh/id_rsa
-hash_behaviour = merge
 # for running on Ubuntu
 #control_path=%(directory)s/%%h-%%r


### PR DESCRIPTION
This reverts commit 7cb5daca68a71018c5b393bfddc63658b4a923d7.